### PR TITLE
chore(ci): fixed name of the project

### DIFF
--- a/.Zeugwerk/config.json
+++ b/.Zeugwerk/config.json
@@ -3,7 +3,7 @@
   "solution": "TcHaxx.Snappy.sln",
   "projects": [
     {
-      "name": "snappy",
+      "name": "TcHaxx.Snappy",
       "plcs": [
         {
           "version": "0.0.4.0",


### PR DESCRIPTION
Related to this PR:
- Fixed the actual bug in Twinpack https://github.com/Zeugwerk/Twinpack/commit/dcfe5b9e4d1b772ba337f2f0c65abc62c6bd7925 (still needs refactoring, but works)
- Passwords in twinpack-action were not quoted, https://github.com/Zeugwerk/twinpack-action/commit/1a1867f407bd07c43073da97469676ea30c6dbbc
- twinpack-action now uses the "--skip-duplicate" argument so it works similarily to alirezanet/publish-nuget now


The project "snappy" doesn't exist in the solution, it is TcHaxx.Snappy instead.
Together with the fix in Twinpack related locating the plcproj files, this should make the CI workflow work.


